### PR TITLE
Given command to make tests was invalid in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ on a computer before deployment on microcontrollers.
 
 To run the tests on computer, simply type the following command in a shell:
 
-> make tests
+> make test
 


### PR DESCRIPTION
The command to compile the tests is `make test` not `make tests`