### PR TITLE
Improved linear_congruential_random_generator()

### DIFF
--- a/src/linear_congruential_random_generator.c
+++ b/src/linear_congruential_random_generator.c
@@ -2,6 +2,8 @@
 
 #include "linear_congruential_random_generator.h"
 
+#include <stdint.h> 
+
 /* The routines below implements the linear congruential random
    number generator. In particular, the function
    "set_linear_congruential_generator_seed" sets the seed of the random
@@ -9,15 +11,15 @@
    returns a pseudo-random real number in the range [0, 1.0]. */
 
 /* Variables and pointers declarations */
-int ISEED = 16.; /* Default value in case the user does not specify the seed */
+uint16_t ISEED = 16; /* Default value in case the user does not specify the seed */
+#define LINEAR_RAND_MAX pow(2, sizeof(ISEED) * 8)
 
-/* Set the seed for the random number generator */
+
 void set_linear_congruential_generator_seed(int num) { ISEED = num; }
 
-/* Linear congruential random number generator */
 lcrg_real linear_congruential_random_generator(void) {
-  ISEED = fmod(75. * ISEED + 74., 65537.);
-  return (ISEED / 65537.);
+  ISEED = 75 * ISEED + 74;
+  return ISEED * (1.0 / LINEAR_RAND_MAX);
 }
 
 /* -- End of file -- */

--- a/src/linear_congruential_random_generator.c
+++ b/src/linear_congruential_random_generator.c
@@ -2,8 +2,6 @@
 
 #include "linear_congruential_random_generator.h"
 
-#include <stdint.h> 
-
 /* The routines below implements the linear congruential random
    number generator. In particular, the function
    "set_linear_congruential_generator_seed" sets the seed of the random
@@ -14,10 +12,9 @@
 uint16_t ISEED = 16; /* Default value in case the user does not specify the seed */
 #define LINEAR_RAND_MAX pow(2, sizeof(ISEED) * 8)
 
+void set_linear_congruential_generator_seed(uint16_t num) { ISEED = num; }
 
-void set_linear_congruential_generator_seed(int num) { ISEED = num; }
-
-lcrg_real linear_congruential_random_generator(void) {
+lcrg_real linear_congruential_random_generator() {
   ISEED = 75 * ISEED + 74;
   return ISEED * (1.0 / LINEAR_RAND_MAX);
 }

--- a/src/linear_congruential_random_generator.h
+++ b/src/linear_congruential_random_generator.h
@@ -1,6 +1,7 @@
 /* This file is part of the 1chipML library. */
 
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -11,7 +12,7 @@
 #define lcrg_real double
 
 /* Functions are defined below */
-void set_linear_congruential_generator_seed(int num);
-lcrg_real linear_congruential_random_generator(void);
+void set_linear_congruential_generator_seed(uint16_t num);
+lcrg_real linear_congruential_random_generator();
 
 /* -- End of file -- */


### PR DESCRIPTION
The current method has some flaws that make it a bit slow on MCU. 
This PR aims to improve the speed of the linear_congruential_random_generator.

I ran some benchmarks to quantify the execution time of each method properly:
 | Method      | Cycles / Call |
| ----------- | ----------- |
| rand()      | 850       |
| random()   | 810        |
|  linear_congruential_random_generator() (old) | 1132 |
|  linear_congruential_random_generator() (new) | 230  |

The main issue was that all operations were made using floating point operation even if they were not needed. We were also able to remove a division using inverse multiplication. 

The observed behavior is the same when running the tests.

We could improve even more the algorithm by removing the multiplication, but this would change the behavior since we would return a number between 0 and LINEAR_RAND_MAX rather than 0 and 1. But removing the multiplication allows us to output a result every 16 cycles.

I think we should do that since in most cases we need a number between 0 and a certain number rather than 0 and 1. This number can usually be obtained using a modulo which only requires ~1 cycle rather than a fp multiplication.

But I need to collect opinions first. @lmusa  @jmsellier